### PR TITLE
Fix Chinese word in config file causes crash

### DIFF
--- a/main.py
+++ b/main.py
@@ -4086,7 +4086,7 @@ class SettingsDialog(QDialog):
 		self.cf.set('filepath', 'ADB_path', self.lineEdit_ADBpath.text())
 		self.cf.set('filepath', 'ADB_port', self.lineEdit_ADBport.text())
 		self.cf.set('filepath', 'watcher_path', self.lineEdit_watcherpath.text())
-		with open('./conf.ini', 'w') as configfile:
+		with open('./conf.ini', 'w', encoding="utf-8") as configfile:
 			self.cf.write(configfile)
 		configfile.close()
 		


### PR DESCRIPTION
Config file saved by wrong encoding and causes crash.
To replicate this issue, fill some UTF-8 characters into conf.ini
![image](https://github.com/user-attachments/assets/abae804f-2e09-4b53-bf58-f22fc8080c3c)
