### PR TITLE
fix: 修复创建表格时缺少table文件夹的BUG

### DIFF
--- a/main.py
+++ b/main.py
@@ -3505,6 +3505,7 @@ class NewCsvDialog(QDialog):
 		if os.path.exists('./table/'  + file_name + '.csv'):
 			print('file Duplicate! Please change a file name.')
 		else:
+			os.makedirs('./table', exist_ok=True)
 			shutil.copy(src_file, dst_folder)
 				
 class DeleteDialog(QDialog):


### PR DESCRIPTION
目前最新版的Release包中缺少一个名为table的空文件夹，导致新建记录表时会报错，创建失败。
更改后可自行创建table文件夹